### PR TITLE
adding staging script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+#!make
+MAKEFLAGS += --silent
+
+# This allows us to accept extra arguments (by doing nothing when we get a job that doesn't match, 
+# rather than throwing an error).
+%: 
+    @: 
+
+# $(MAKECMDGOALS) is the list of "targets" spelled out on the command line
+stagel: 
+	git clone --quiet https://github.com/mongodb/snooty-scripts.git build_scripts
+	@ cd build_scripts && npm list mongodb || npm install mongodb
+	@ source ~/.config/.snootyenv && node build_scripts/app.js $(filter-out $@,$(MAKECMDGOALS))
+	@ rm -rf build_scripts
+
+commit:
+        @:
+
+local:
+        @:
+
+repo:
+        @:
+
+world:
+        @:
+
+clean: 
+	rm -rf build
+
+.PHONY: stage
+.PHONY: clean


### PR DESCRIPTION
The staging script allows writers to stage their content in Snooty without requiring a push to github.

Usage:

In the root of the repository, run:

- make stagel local  -- stages the content of the repository that has been changed but not committed
- make stagel commit -- stages only content that has been committed
