### PR TITLE
Remove slack reference

### DIFF
--- a/source/article/enterprise-operator-kubernetes-openshift.txt
+++ b/source/article/enterprise-operator-kubernetes-openshift.txt
@@ -635,9 +635,6 @@ Introducing the MongoDB Enterprise Operator for Kubernetes and OpenShift
    website <https://docs.mongodb.com/manual/>`_ in the near future. Until
    then check out these resources for more information: 
    
-   Slack:
-   #enterprise-kubernetes 
-   
    Sign up @ https://launchpass.com/mongo-db 
    
    GitHub:


### PR DESCRIPTION
Remove the Slack reference because it doesn't make any sense
Preview: http://docs-devhub-staging.s3-website-us-east-1.amazonaws.com/8c7d2c6/devhub/docsworker/fix-kubernetes-article/article/enterprise-operator-kubernetes-openshift